### PR TITLE
FIX issues #1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module appliedgo.net/what
+module github.com/appliedgocode/what
 
 go 1.13
 


### PR DESCRIPTION
FIX github.com/appliedgocode/what

➜  ~ go get github.com/appliedgocode/what
go: github.com/appliedgocode/what upgrade => v0.1.1
go get: github.com/appliedgocode/what@v0.1.1: parsing go.mod:
	module declares its path as: appliedgo.net/what
	        but was required as: github.com/appliedgocode/what